### PR TITLE
Improve version upgrade calculation

### DIFF
--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
@@ -72,6 +72,12 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
   private boolean allowRecursiveReactorOutput;
 
   /**
+   * The current version to be used for calculation.
+   */
+  @Parameter(property = "currentVersion", defaultValue = "${project.version}")
+  private String currentVersion;
+
+  /**
    * Utility method to write a content in a given file.
    *
    * @param output  is the wanted output file.
@@ -139,7 +145,7 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     final int projectIndex = this.reactorProjects.indexOf(this.project);
     if (projectIndex == 0 || this.allowRecursiveReactorOutput) {
-      final String result = calculateVersion(this.project.getVersion());
+      final String result = calculateVersion(this.currentVersion);
       handleResultOutput(result, projectIndex);
     }
   }

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/NextSnapshotVersionMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/NextSnapshotVersionMojo.java
@@ -7,8 +7,8 @@ import com.itemis.maven.plugins.unleash.util.MavenVersionUtil;
 import com.itemis.maven.plugins.unleash.util.VersionUpgradeStrategy;
 
 /**
- * Print the release version calculated for this project by {@link MavenVersionUtil#calculateReleaseVersion(String)}.
- *
+ * Print the next development version calculated for this project by
+ * {@link MavenVersionUtil#calculateNextSnapshotVersion(String, VersionUpgradeStrategy)}
  *
  * @author <a href="mailto:mhoffrogge@gmail.com">Markus Hoffrogge</a>
  * @since 3.1.0

--- a/utils/src/main/java/com/itemis/maven/plugins/unleash/util/Version.java
+++ b/utils/src/main/java/com/itemis/maven/plugins/unleash/util/Version.java
@@ -62,17 +62,17 @@ class Version {
   }
 
   private void increaseSpecificSegment(short index) {
-    if (index >= this.segments.size() || index < 0) {
-      increaseLowestPossibleSegment();
-    } else {
-      String segment = this.segments.get(index);
+    for (short increasableIndex = index; increasableIndex < this.segments.size()
+        && increasableIndex >= 0; increasableIndex++) {
+      String segment = this.segments.get(increasableIndex);
       String increasedSegment = increaseSegment(segment);
-      if (Objects.equal(segment, increasedSegment)) {
-        increaseLowestPossibleSegment();
-      } else {
-        this.segments.set(index, increasedSegment);
+      if (!Objects.equal(segment, increasedSegment)) {
+        this.segments.set(increasableIndex, increasedSegment);
+        return;
       }
     }
+    // No increasable part found yet
+    increaseLowestPossibleSegment();
   }
 
   private String increaseSegment(String segment) {
@@ -97,8 +97,14 @@ class Version {
       if (start == -1) {
         start = 0;
       }
-      int toIncrease = Integer.parseInt(sb.substring(start, end + 1));
-      sb.replace(start, end + 1, Integer.toString(toIncrease + 1));
+      int lengthForLeadingZeroes = 0;
+      String sNumber = sb.substring(start, end + 1);
+      if (sNumber.startsWith("0")) {
+        lengthForLeadingZeroes = sNumber.length();
+      }
+      int increasedNumber = Integer.parseInt(sNumber) + 1;
+      sNumber = String.format(lengthForLeadingZeroes > 0 ? "%0" + lengthForLeadingZeroes + "d" : "%d", increasedNumber);
+      sb.replace(start, end + 1, sNumber);
     }
 
     return sb.toString();
@@ -111,11 +117,9 @@ class Version {
     }
 
     Iterator<String> segmentsIterator = this.segments.iterator();
-    Iterator<Character> separatorsIterator = this.separators.iterator();
-
     StringBuilder sb = new StringBuilder(segmentsIterator.next());
-    while (separatorsIterator.hasNext()) {
-      sb.append(separatorsIterator.next());
+    for (Character separator : this.separators) {
+      sb.append(separator);
       sb.append(segmentsIterator.next());
     }
 

--- a/utils/src/main/java/com/itemis/maven/plugins/unleash/util/VersionUpgradeStrategy.java
+++ b/utils/src/main/java/com/itemis/maven/plugins/unleash/util/VersionUpgradeStrategy.java
@@ -19,6 +19,26 @@ public enum VersionUpgradeStrategy {
    */
   INCREMENTAL((short) 2),
   /**
+   * The fourth part of the version (index 3).
+   */
+  BUILD((short) 3),
+  /**
+   * The fifth part of the version (index 4).
+   */
+  PART_5((short) 4),
+  /**
+   * The sixth part of the version (index 5).
+   */
+  PART_6((short) 5),
+  /**
+   * The seventh part of the version (index 6).
+   */
+  PART_7((short) 6),
+  /**
+   * The eighth part of the version (index 7).
+   */
+  PART_8((short) 7),
+  /**
    * The lowest possible (rightmost) part of the version (index -1).
    */
   DEFAULT((short) -1);

--- a/utils/src/test/java/com/itemis/maven/plugins/unleash/util/MavenVersionUtilTest.java
+++ b/utils/src/test/java/com/itemis/maven/plugins/unleash/util/MavenVersionUtilTest.java
@@ -22,7 +22,13 @@ public class MavenVersionUtilTest {
   public static Object[][] calculateNextSnapshotVersion() {
     return new Object[][] { { "3.8.1", "3.8.2-SNAPSHOT" }, { "1.0.0-SNAPSHOT", "1.0.1-SNAPSHOT" },
         { "1.12", "1.13-SNAPSHOT" }, { "1.3-SNAPSH", "1.4-SNAPSH-SNAPSHOT" }, { "3-Alpha1", "3-Alpha2-SNAPSHOT" },
-        { "3-Alpha1-SNAPSHOT", "3-Alpha2-SNAPSHOT" }, { "1-SNAPSHOT", "2-SNAPSHOT" }, { "3", "4-SNAPSHOT" } };
+        { "3-Alpha1-SNAPSHOT", "3-Alpha2-SNAPSHOT" }, { "1-SNAPSHOT", "2-SNAPSHOT" }, { "3", "4-SNAPSHOT" },
+        // leading zero cases
+        { "01.02.03.001-SNAPSHOT", "01.02.03.002-SNAPSHOT" }, { "01.02.03.099-SNAPSHOT", "01.02.03.100-SNAPSHOT" },
+        { "3-Alpha01-SNAPSHOT", "3-Alpha02-SNAPSHOT" }, { "3-Alpha+01-SNAPSHOT", "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01-SNAPSHOT", "3-Alpha-02-SNAPSHOT" }, { "3-Alpha.01-SNAPSHOT", "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01.1", "3-Alpha+01.2-SNAPSHOT" }, { "3-Alpha-01.1", "3-Alpha-01.2-SNAPSHOT" },
+        { "3-Alpha.01.1", "3-Alpha.01.2-SNAPSHOT" } };
   }
 
   @DataProvider
@@ -33,6 +39,22 @@ public class MavenVersionUtilTest {
         { "1.3-SNAPSH", VersionUpgradeStrategy.MAJOR, "2.3-SNAPSH-SNAPSHOT" },
         { "3-Alpha1", VersionUpgradeStrategy.DEFAULT, "3-Alpha2-SNAPSHOT" },
         { "3-Alpha1-SNAPSHOT", null, "3-Alpha2-SNAPSHOT" },
+        { "3-Alpha01", VersionUpgradeStrategy.DEFAULT, "3-Alpha02-SNAPSHOT" },
+        { "3-Alpha+01", VersionUpgradeStrategy.MINOR, "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01", VersionUpgradeStrategy.MINOR, "3-Alpha-02-SNAPSHOT" },
+        { "3-Alpha.01", VersionUpgradeStrategy.MINOR, "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha-02-SNAPSHOT" },
+        { "3-Alpha.01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01.1", VersionUpgradeStrategy.MINOR, "3-Alpha+02.1-SNAPSHOT" },
+        { "3-Alpha-01.1", VersionUpgradeStrategy.MINOR, "3-Alpha-02.1-SNAPSHOT" },
+        { "3-Alpha.01.1", VersionUpgradeStrategy.MINOR, "3-Alpha.02.1-SNAPSHOT" },
+        { "3-Alpha+01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha+01.2-SNAPSHOT" },
+        { "3-Alpha-01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha-02.1-SNAPSHOT" },
+        { "3-Alpha.01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha.02.1-SNAPSHOT" },
+        { "3-Alpha+01.1.2", VersionUpgradeStrategy.BUILD, "3-Alpha+01.1.3-SNAPSHOT" },
+        { "3-Alpha-01.1.2", VersionUpgradeStrategy.BUILD, "3-Alpha-01.2.2-SNAPSHOT" },
+        { "3-Alpha.01.01.2", VersionUpgradeStrategy.BUILD, "3-Alpha.01.02.2-SNAPSHOT" },
         { "1.1.1-SNAPSHOT", VersionUpgradeStrategy.INCREMENTAL, "1.1.2-SNAPSHOT" } };
   }
 


### PR DESCRIPTION
- Preserve leading 0 for increased version parts with the same number of digits if not exceeding the digits required for the new value

- Add optional system property currentVersion to goals unleash:nextSnapshotVersion and unleash:releaseVersion Default is ${project.version}. This property is being used as the base for any version calculation.

- Add further VersionUpgradeStrategy options:
  - BUILD - 4th version part
  - PART_5 - 5th version part
  - PART_6 - 6th version part
  - PART_7 - 7th version part
  - PART_8 - 8th version part