### PR TITLE
Fix SetNextDev to commit properly if Maven project is in a subfolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,55 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TBD
 
 
+## [3.2.0]
+<!-- !!! Align version in badge URLs as well !!! -->
+[![3.2.0 Badge](https://img.shields.io/nexus/r/io.github.mavenplugins/unleash-maven-plugin?server=https://s01.oss.sonatype.org&label=Maven%20Central&queryOpt=:v=3.2.0)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.2.0)
+
+### Summary
+- Preserve leading `0` for increased version parts with the same number of digits if not exceeding the digits required for the new value.
+- Add optional system property `currentVersion` to goals `unleash:nextSnapshotVersion` and `unleash:releaseVersion`.
+  Default is `${project.version}`. This property is being used as the base for any version calculation.
+- Add further `VersionUpgradeStrategy` options:
+  - `BUILD` - 4th version part
+  - `PART_5` - 5th version part
+  - `PART_6` - 6th version part
+  - `PART_7` - 7th version part
+  - `PART_8` - 8th version part
+- Refactor class `FileToRelativePath` as a pre-requisite to fix `unleash-scm-provider-git`
+  to work with Maven projects located in a sub folder of the checkout folder.
+
+### :bug: Bugfix
+- Fix issue raised by workflow step `SetNextDevVersion` for Git SCM projects:
+  If the Maven project base dir is within a sub folder of the git checkout directory,
+  then the next dev modified POMs did not get recognized as changed files to be commited.<br>
+  👉 Requires `unleash-scm-provider-git` version `3.1.0` or later!
+
+### Updates
+- pom.xml:
+  - update parent pom version
+
+- Plugin Mojo classes:
+  - AbstractVersionMojo.java:
+    - add property `currentVersion`
+  - NextSnapshotVersionMojo.java:
+    - fix class comment
+  
+- Version calculation classes:
+  - Version.java:
+    - preserve leading 0's of version part being increased
+  - VersionUpgradeStrategy.java:
+    - add version part options (s. Summary)
+  - MavenVersionUtilTest.java:
+    - Add according test cases
+
+- Others:
+  - Deprecate `com.itemis.maven.plugins.unleash.util.FileToRelativePath`
+    - this is moved to `com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath`
+  - FollowUp refactored classes:
+    - DetectReleaseArtifacts.java
+    - DevVersionUtil.java
+
+
 ## [3.1.0]
 <!-- !!! Align version in badge URLs as well !!! -->
 [![3.1.0 Badge](https://img.shields.io/nexus/r/io.github.mavenplugins/unleash-maven-plugin?server=https://s01.oss.sonatype.org&label=Maven%20Central&queryOpt=:v=3.1.0)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.1.0)
@@ -254,7 +303,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This is just a dummy placeholder to make the parser of GHCICD/release-notes-from-changelog@v1 happy!
 -->
 
-[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.1.0..HEAD
+[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.2.0..HEAD
+[3.2.0]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.1.0..v3.2.0
 [3.1.0]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.0.3..v3.1.0
 [3.0.3]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.0.2..v3.0.3
 [3.0.2]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.0.1..v3.0.2

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>unleash-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
@@ -72,6 +72,12 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
   private boolean allowRecursiveReactorOutput;
 
   /**
+   * The current version to be used for calculation.
+   */
+  @Parameter(property = "currentVersion", defaultValue = "${project.version}")
+  private String currentVersion;
+
+  /**
    * Utility method to write a content in a given file.
    *
    * @param output  is the wanted output file.
@@ -139,7 +145,7 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     final int projectIndex = this.reactorProjects.indexOf(this.project);
     if (projectIndex == 0 || this.allowRecursiveReactorOutput) {
-      final String result = calculateVersion(this.project.getVersion());
+      final String result = calculateVersion(this.currentVersion);
       handleResultOutput(result, projectIndex);
     }
   }

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/NextSnapshotVersionMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/NextSnapshotVersionMojo.java
@@ -7,8 +7,8 @@ import com.itemis.maven.plugins.unleash.util.MavenVersionUtil;
 import com.itemis.maven.plugins.unleash.util.VersionUpgradeStrategy;
 
 /**
- * Print the release version calculated for this project by {@link MavenVersionUtil#calculateReleaseVersion(String)}.
- *
+ * Print the next development version calculated for this project by
+ * {@link MavenVersionUtil#calculateNextSnapshotVersion(String, VersionUpgradeStrategy)}
  *
  * @author <a href="mailto:mhoffrogge@gmail.com">Markus Hoffrogge</a>
  * @since 3.1.0

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
@@ -22,7 +22,7 @@ import com.itemis.maven.plugins.cdi.annotations.ProcessingStep;
 import com.itemis.maven.plugins.cdi.logging.Logger;
 import com.itemis.maven.plugins.unleash.ReleaseMetadata;
 import com.itemis.maven.plugins.unleash.ReleasePhase;
-import com.itemis.maven.plugins.unleash.util.functions.FileToRelativePath;
+import com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath;
 import com.itemis.maven.plugins.unleash.util.functions.ProjectToString;
 
 import jakarta.inject.Inject;

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
@@ -14,7 +14,7 @@ import com.itemis.maven.plugins.unleash.ReleaseMetadata;
 import com.itemis.maven.plugins.unleash.scm.ScmProvider;
 import com.itemis.maven.plugins.unleash.scm.requests.CommitRequest;
 import com.itemis.maven.plugins.unleash.scm.requests.CommitRequest.Builder;
-import com.itemis.maven.plugins.unleash.util.functions.FileToRelativePath;
+import com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath;
 import com.itemis.maven.plugins.unleash.util.scm.ScmPomVersionsMergeClient;
 import com.itemis.maven.plugins.unleash.util.scm.ScmProviderRegistry;
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/FileToRelativePath.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/FileToRelativePath.java
@@ -1,0 +1,18 @@
+package com.itemis.maven.plugins.unleash.util;
+
+import java.io.File;
+
+/**
+ * A function to convert a file's absolute path into the relative path starting from a reference file.
+ *
+ * @author <a href="mailto:stanley.hillner@itemis.de">Stanley Hillner</a>
+ * @since 1.0.0
+ * @deprecated Use {@link com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath} instead.
+ */
+@Deprecated
+public class FileToRelativePath extends com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath {
+
+  public FileToRelativePath(File workingDir) {
+    super(workingDir);
+  }
+}

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
+import com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>org-parent</artifactId>
-    <version>7</version>
+    <version>8</version>
     <relativePath/>
   </parent>
 
   <artifactId>unleash-parent</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Unleash Parent</name>
@@ -65,7 +65,7 @@
     <version.artifact-spy-plugin>1.0.7</version.artifact-spy-plugin>
     <version.cdi-plugin-utils>4.0.0</version.cdi-plugin-utils>
     <!-- Resolve chicken/egg unleash by defining specific unleash commandline goal: -->
-    <version.unleash-maven-plugin.perform>3.0.3</version.unleash-maven-plugin.perform>
+    <version.unleash-maven-plugin.perform>3.1.0</version.unleash-maven-plugin.perform>
     <unleash.goal>perform</unleash.goal>
     <!-- This is considered by the reusable GH unleash action: -->
     <unleash.cmdline.goal>

--- a/scm-provider-api/pom.xml
+++ b/scm-provider-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>unleash-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
+++ b/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
@@ -1,4 +1,4 @@
-package com.itemis.maven.plugins.unleash.util.functions;
+package com.itemis.maven.plugins.unleash.scm.utils;
 
 import java.io.File;
 import java.net.URI;
@@ -11,9 +11,10 @@ import com.google.common.base.Function;
 
 /**
  * A function to convert a file's absolute path into the relative path starting from a reference file.
+ * (identical to former {@link com.itemis.maven.plugins.unleash.util.FileToRelativePath})
  *
  * @author <a href="mailto:stanley.hillner@itemis.de">Stanley Hillner</a>
- * @since 1.0.0
+ * @since 3.2.0
  */
 public class FileToRelativePath implements Function<File, String> {
   private File workingDir;

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>unleash-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/utils/src/main/java/com/itemis/maven/plugins/unleash/util/Version.java
+++ b/utils/src/main/java/com/itemis/maven/plugins/unleash/util/Version.java
@@ -62,17 +62,17 @@ class Version {
   }
 
   private void increaseSpecificSegment(short index) {
-    if (index >= this.segments.size() || index < 0) {
-      increaseLowestPossibleSegment();
-    } else {
-      String segment = this.segments.get(index);
+    for (short increasableIndex = index; increasableIndex < this.segments.size()
+        && increasableIndex >= 0; increasableIndex++) {
+      String segment = this.segments.get(increasableIndex);
       String increasedSegment = increaseSegment(segment);
-      if (Objects.equal(segment, increasedSegment)) {
-        increaseLowestPossibleSegment();
-      } else {
-        this.segments.set(index, increasedSegment);
+      if (!Objects.equal(segment, increasedSegment)) {
+        this.segments.set(increasableIndex, increasedSegment);
+        return;
       }
     }
+    // No increasable part found yet
+    increaseLowestPossibleSegment();
   }
 
   private String increaseSegment(String segment) {
@@ -97,8 +97,14 @@ class Version {
       if (start == -1) {
         start = 0;
       }
-      int toIncrease = Integer.parseInt(sb.substring(start, end + 1));
-      sb.replace(start, end + 1, Integer.toString(toIncrease + 1));
+      int lengthForLeadingZeroes = 0;
+      String sNumber = sb.substring(start, end + 1);
+      if (sNumber.startsWith("0")) {
+        lengthForLeadingZeroes = sNumber.length();
+      }
+      int increasedNumber = Integer.parseInt(sNumber) + 1;
+      sNumber = String.format(lengthForLeadingZeroes > 0 ? "%0" + lengthForLeadingZeroes + "d" : "%d", increasedNumber);
+      sb.replace(start, end + 1, sNumber);
     }
 
     return sb.toString();
@@ -111,11 +117,9 @@ class Version {
     }
 
     Iterator<String> segmentsIterator = this.segments.iterator();
-    Iterator<Character> separatorsIterator = this.separators.iterator();
-
     StringBuilder sb = new StringBuilder(segmentsIterator.next());
-    while (separatorsIterator.hasNext()) {
-      sb.append(separatorsIterator.next());
+    for (Character separator : this.separators) {
+      sb.append(separator);
       sb.append(segmentsIterator.next());
     }
 

--- a/utils/src/main/java/com/itemis/maven/plugins/unleash/util/VersionUpgradeStrategy.java
+++ b/utils/src/main/java/com/itemis/maven/plugins/unleash/util/VersionUpgradeStrategy.java
@@ -19,6 +19,26 @@ public enum VersionUpgradeStrategy {
    */
   INCREMENTAL((short) 2),
   /**
+   * The fourth part of the version (index 3).
+   */
+  BUILD((short) 3),
+  /**
+   * The fifth part of the version (index 4).
+   */
+  PART_5((short) 4),
+  /**
+   * The sixth part of the version (index 5).
+   */
+  PART_6((short) 5),
+  /**
+   * The seventh part of the version (index 6).
+   */
+  PART_7((short) 6),
+  /**
+   * The eighth part of the version (index 7).
+   */
+  PART_8((short) 7),
+  /**
    * The lowest possible (rightmost) part of the version (index -1).
    */
   DEFAULT((short) -1);

--- a/utils/src/test/java/com/itemis/maven/plugins/unleash/util/MavenVersionUtilTest.java
+++ b/utils/src/test/java/com/itemis/maven/plugins/unleash/util/MavenVersionUtilTest.java
@@ -22,7 +22,13 @@ public class MavenVersionUtilTest {
   public static Object[][] calculateNextSnapshotVersion() {
     return new Object[][] { { "3.8.1", "3.8.2-SNAPSHOT" }, { "1.0.0-SNAPSHOT", "1.0.1-SNAPSHOT" },
         { "1.12", "1.13-SNAPSHOT" }, { "1.3-SNAPSH", "1.4-SNAPSH-SNAPSHOT" }, { "3-Alpha1", "3-Alpha2-SNAPSHOT" },
-        { "3-Alpha1-SNAPSHOT", "3-Alpha2-SNAPSHOT" }, { "1-SNAPSHOT", "2-SNAPSHOT" }, { "3", "4-SNAPSHOT" } };
+        { "3-Alpha1-SNAPSHOT", "3-Alpha2-SNAPSHOT" }, { "1-SNAPSHOT", "2-SNAPSHOT" }, { "3", "4-SNAPSHOT" },
+        // leading zero cases
+        { "01.02.03.001-SNAPSHOT", "01.02.03.002-SNAPSHOT" }, { "01.02.03.099-SNAPSHOT", "01.02.03.100-SNAPSHOT" },
+        { "3-Alpha01-SNAPSHOT", "3-Alpha02-SNAPSHOT" }, { "3-Alpha+01-SNAPSHOT", "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01-SNAPSHOT", "3-Alpha-02-SNAPSHOT" }, { "3-Alpha.01-SNAPSHOT", "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01.1", "3-Alpha+01.2-SNAPSHOT" }, { "3-Alpha-01.1", "3-Alpha-01.2-SNAPSHOT" },
+        { "3-Alpha.01.1", "3-Alpha.01.2-SNAPSHOT" } };
   }
 
   @DataProvider
@@ -33,6 +39,22 @@ public class MavenVersionUtilTest {
         { "1.3-SNAPSH", VersionUpgradeStrategy.MAJOR, "2.3-SNAPSH-SNAPSHOT" },
         { "3-Alpha1", VersionUpgradeStrategy.DEFAULT, "3-Alpha2-SNAPSHOT" },
         { "3-Alpha1-SNAPSHOT", null, "3-Alpha2-SNAPSHOT" },
+        { "3-Alpha01", VersionUpgradeStrategy.DEFAULT, "3-Alpha02-SNAPSHOT" },
+        { "3-Alpha+01", VersionUpgradeStrategy.MINOR, "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01", VersionUpgradeStrategy.MINOR, "3-Alpha-02-SNAPSHOT" },
+        { "3-Alpha.01", VersionUpgradeStrategy.MINOR, "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha+02-SNAPSHOT" },
+        { "3-Alpha-01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha-02-SNAPSHOT" },
+        { "3-Alpha.01", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha.02-SNAPSHOT" },
+        { "3-Alpha+01.1", VersionUpgradeStrategy.MINOR, "3-Alpha+02.1-SNAPSHOT" },
+        { "3-Alpha-01.1", VersionUpgradeStrategy.MINOR, "3-Alpha-02.1-SNAPSHOT" },
+        { "3-Alpha.01.1", VersionUpgradeStrategy.MINOR, "3-Alpha.02.1-SNAPSHOT" },
+        { "3-Alpha+01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha+01.2-SNAPSHOT" },
+        { "3-Alpha-01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha-02.1-SNAPSHOT" },
+        { "3-Alpha.01.1", VersionUpgradeStrategy.INCREMENTAL, "3-Alpha.02.1-SNAPSHOT" },
+        { "3-Alpha+01.1.2", VersionUpgradeStrategy.BUILD, "3-Alpha+01.1.3-SNAPSHOT" },
+        { "3-Alpha-01.1.2", VersionUpgradeStrategy.BUILD, "3-Alpha-01.2.2-SNAPSHOT" },
+        { "3-Alpha.01.01.2", VersionUpgradeStrategy.BUILD, "3-Alpha.01.02.2-SNAPSHOT" },
         { "1.1.1-SNAPSHOT", VersionUpgradeStrategy.INCREMENTAL, "1.1.2-SNAPSHOT" } };
   }
 


### PR DESCRIPTION
- Fix issue raised by workflow step `SetNextDevVersion` for Git SCM projects:
  If the Maven project base dir is within a sub folder of the git checkout directory,
  then in this case the next dev modified POMs did not get recognized as changed files to be commited.<br>
  👉 Requires `unleash-scm-provider-git` version `3.1.0` or later!
