### PR TITLE
Fix vulnerability warnings on dependencies

### DIFF
--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/PomUtilTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/PomUtilTest.java
@@ -16,12 +16,9 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -34,8 +31,6 @@ import com.google.common.base.Optional;
 import com.google.common.io.Closeables;
 
 public class PomUtilTest {
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Rule
   public TemporaryFolder TemporaryFolder = new TemporaryFolder();
@@ -92,29 +87,19 @@ public class PomUtilTest {
 
   @Test
   public void testParsePOM_Invalid() {
-    this.exception.expect(RuntimeException.class);
-    this.exception.expectCause(new BaseMatcher<Throwable>() {
-
-      @Override
-      public boolean matches(Object item) {
-        return item instanceof SAXParseException;
+    final RuntimeException thrown = Assert.assertThrows(RuntimeException.class, () -> {
+      URL url = getClass().getResource(getClass().getSimpleName() + "/pom2.xml");
+      File f;
+      try {
+        f = new File(url.toURI());
+      } catch (URISyntaxException e) {
+        f = new File(url.getPath());
       }
 
-      @Override
-      public void describeTo(Description description) {
-      }
+      PomUtil.parsePOM(f);
+      Assert.fail("Parser should throw an exception since the document is not well formed!");
     });
-
-    URL url = getClass().getResource(getClass().getSimpleName() + "/pom2.xml");
-    File f;
-    try {
-      f = new File(url.toURI());
-    } catch (URISyntaxException e) {
-      f = new File(url.getPath());
-    }
-
-    PomUtil.parsePOM(f);
-    Assert.fail("Parser should throw an exception since the document is not well formed!");
+    Assert.assertTrue(thrown.getCause() instanceof SAXParseException);
   }
 
   @Test

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/ReleaseUtilTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/ReleaseUtilTest.java
@@ -2,9 +2,7 @@ package com.itemis.maven.plugins.unleash.util;
 
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -36,9 +34,6 @@ public class ReleaseUtilTest {
   // return new Object[][] { { "test", null }, { null, p }, { null, null } };
   // }
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   // @Test
   // @UseDataProvider("getTagName")
   // public void testGetTagName(String tagNamePattern, MavenProject project, String expectedTagName) {
@@ -46,10 +41,9 @@ public class ReleaseUtilTest {
   // Assert.assertEquals(expectedTagName, name);
   // }
   //
-  // @Test
+  // @Test(expected = IllegalArgumentException.class)
   // @UseDataProvider("getTagName_Exception")
   // public void testGetTagNameNoProject(String tagNamePattern, MavenProject project) {
-  // this.exception.expect(IllegalArgumentException.class);
   // ReleaseUtil.getTagName(tagNamePattern, project);
   // }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  child.project.url.inherit.append.path="false"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>io.github.mavenplugins</groupId>
     <artifactId>org-parent</artifactId>
     <version>8</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <artifactId>unleash-parent</artifactId>
@@ -23,13 +26,6 @@
 
   <developers>
     <developer>
-      <id>shillner</id>
-      <name>Stanley Hillner</name>
-      <organization>itemis AG</organization>
-      <organizationUrl>https://itemis.com/</organizationUrl>
-      <timezone>1</timezone>
-    </developer>
-    <developer>
       <id>mavenplugins</id>
       <!-- Let Maven Central Search show 'Public Project' as known contributors tag -->
       <name>Public Project</name>
@@ -38,9 +34,17 @@
       <organizationUrl>https://github.com/mavenplugins/</organizationUrl>
       <timezone>1</timezone>
     </developer>
+    <developer>
+      <id>shillner</id>
+      <name>Stanley Hillner</name>
+      <organization>itemis AG</organization>
+      <organizationUrl>https://itemis.com/</organizationUrl>
+      <timezone>1</timezone>
+    </developer>
   </developers>
 
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false"
+    child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/mavenplugins/unleash-maven-plugin.git</connection>
     <url>https://github.com/mavenplugins/unleash-maven-plugin</url>
     <tag>HEAD</tag>
@@ -63,9 +67,9 @@
     <!-- UNLEASH -->
     <version.unleash-maven-plugin>${project.version}</version.unleash-maven-plugin>
     <version.artifact-spy-plugin>1.0.7</version.artifact-spy-plugin>
-    <version.cdi-plugin-utils>4.0.0</version.cdi-plugin-utils>
+    <version.cdi-plugin-utils>4.0.1-SNAPSHOT</version.cdi-plugin-utils>
     <!-- Resolve chicken/egg unleash by defining specific unleash commandline goal: -->
-    <version.unleash-maven-plugin.perform>3.1.0</version.unleash-maven-plugin.perform>
+    <version.unleash-maven-plugin.perform>3.2.0</version.unleash-maven-plugin.perform>
     <unleash.goal>perform</unleash.goal>
     <!-- This is considered by the reusable GH unleash action: -->
     <unleash.cmdline.goal>
@@ -79,10 +83,10 @@
     <version.plexus-interactivity-api>1.3</version.plexus-interactivity-api>
     <version.tycho-versions-plugin>1.1.0</version.tycho-versions-plugin>
     <!-- 3rd PARTY -->
-    <version.guava>23.0</version.guava>
+    <version.guava.minimum_provided>33.0.0-jre</version.guava.minimum_provided>
     <version.commons-lang3>3.4</version.commons-lang3>
     <!-- TEST -->
-    <version.junit>4.12</version.junit>
+    <version.junit>4.13.2</version.junit>
     <version.junit-dataprovider>1.13.1</version.junit-dataprovider>
     <version.mockito-all>1.10.19</version.mockito-all>
   </properties>
@@ -150,11 +154,6 @@
       </dependency>
 
       <!-- 3rd PARTY DEPENDENCIES -->
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${version.guava}</version>
-      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>

--- a/scm-provider-api/pom.xml
+++ b/scm-provider-api/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -20,10 +22,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -20,6 +22,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>${version.guava.minimum_provided}</version>
+      <!-- In Maven runtime this will be provided by cdi-utils. -->
+      <!-- In JenkinsCI runtime this will provided by Jenkins. -->
+      <scope>provided</scope>
     </dependency>
 
     <!-- TEST DEPENDENCIES -->


### PR DESCRIPTION
- pom.xml:
  - Update dependency io.github.mavenplugins:cdi-plugin-utils:4.0.0 -> io.github.mavenplugins:cdi-plugin-utils:4.0.1
  - Remove dependency management definition for `com.google.guava:guava`
  - Update dependency junit:junit:4.12` -> `junit:junit:4.13.2
  - Update property <version.guava>23.0</version.guava> -> <version.guava.minimum_provided>33.0.0-jre</version.guava.minimum_provided>

- utils/pom.xml:
  - Update dependency scope for com.google.guava:guava to provided

- scm-provider-api/pom.xml:
  - Remove explicit dependency to com.google.guava:guava

- PomUtilTest.java, ReleaseUtilTest.java:
  - Fix for deprecation warning on ExpectedException.none()