### PR TITLE
Update dependency to org.apache.commons:commons-lang3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     - dependency-name: "org.codehaus.mojo:versions-maven-plugin"
     # ignore commons-lang3 - will be managed manually!
     - dependency-name: "org.apache.commons:commons-lang3"
+    # ignore commons-text - will be managed manually!
+    - dependency-name: "org.apache.commons:commons-text"
     # ignore plexus-interactivity-api - will be managed manually!
     - dependency-name: "org.codehaus.plexus:plexus-interactivity-api"
     # ignore tycho-versions-plugin - will be managed manually!

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -78,7 +80,8 @@
     <!-- 3rd PARTY DEPENDENCIES -->
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
+      <artifactId>commons-text</artifactId>
+      <version>${version.commons-text}</version>
     </dependency>
 
     <!-- MAVEN DEPENDENCIES -->

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractVersionMojo.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -117,7 +116,7 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
     if (this.output != null) {
       StringBuilder sb = new StringBuilder();
       if (projectIndex > 0) {
-        sb.append(SystemUtils.LINE_SEPARATOR);
+        sb.append(System.lineSeparator());
       }
       sb.append(result);
       try {
@@ -128,11 +127,11 @@ public abstract class AbstractVersionMojo extends AbstractMojo {
       getLog().info("Result written to: " + this.output);
     } else {
       if (getLog().isInfoEnabled()) {
-        getLog().info(SystemUtils.LINE_SEPARATOR + result);
+        getLog().info(System.lineSeparator() + result);
       } else {
         if (this.forceStdout) {
           if (projectIndex > 0) {
-            System.out.print(SystemUtils.LINE_SEPARATOR);
+            System.out.print(System.lineSeparator());
           }
           System.out.print(result);
           System.out.flush();

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/ScmMessagePrefixUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/ScmMessagePrefixUtil.java
@@ -3,8 +3,8 @@
  */
 package com.itemis.maven.plugins.unleash.util;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * @author mhoffrog

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,9 @@
     <version.tycho-versions-plugin>1.1.0</version.tycho-versions-plugin>
     <!-- 3rd PARTY -->
     <version.guava.minimum_provided>33.0.0-jre</version.guava.minimum_provided>
-    <version.commons-lang3>3.4</version.commons-lang3>
+    <version.commons-text>1.10.0</version.commons-text>
+    <!-- commons-lang3 version must comply with commons-text version! -->
+    <version.commons-lang3>3.12.0</version.commons-lang3>
     <!-- TEST -->
     <version.junit>4.13.2</version.junit>
     <version.junit-dataprovider>1.13.1</version.junit-dataprovider>
@@ -154,11 +156,6 @@
       </dependency>
 
       <!-- 3rd PARTY DEPENDENCIES -->
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${version.commons-lang3}</version>
-      </dependency>
 
       <!-- TEST DEPENDENCIES -->
       <dependency>

--- a/scm-provider-api/pom.xml
+++ b/scm-provider-api/pom.xml
@@ -22,6 +22,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>${version.commons-lang3}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Update dependency to org.apache.commons:commons-lang3

- pom.xml:
  - Update property <version.commons-lang3>3.4</version.commons-lang3>
    -> <version.commons-lang3>3.12.0</version.commons-lang3>
  - Remove dependency management for `org.apache.commons:commons-lang3`
  - Add property <version.commons-text>1.10.0</version.commons-text>

- unleash-maven-plugin/pom.xml:
  - Update managed dependency org.apache.commons:commons-lang3:3.4
    -> unmanaged org.apache.commons:commons-lang3:3.12.0
  - Add unmanaged dependency org.apache.commons:commons-text:1.10.0

- scm-provider-api/pom.xml:
  - Update managed dependency org.apache.commons:commons-lang3:3.4
    -> unmanaged org.apache.commons:commons-lang3:3.12.0

- AbstractVersionMojo.java:
  - Rreplace usage of deprecated SystemUtils.LINE_SEPARATOR by System.lineSeparator()

- ScmMessagePrefixUtil.java:
  - Replace usage of deprecated org.apache.commons.lang3.StringEscapeUtils
    by org.apache.commons.text.StringEscapeUtils