### PR TITLE
Fix security warnings on GitHub Actions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,6 +20,11 @@ on:
       - 'CHANGELOG.md'
       - 'LICENSE'
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   job1_Call_Build_and_Deploy:
     name: Build ${{ github.repository }}

--- a/.github/workflows/unleash.yml
+++ b/.github/workflows/unleash.yml
@@ -23,6 +23,11 @@ on:
 #    tags:
 #      - '*'
 
+# Default permissions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # Deploy next snapshot
   job1_Call_Unleash:


### PR DESCRIPTION
# Changes
- build_and_deploy.yml, unleash.yml:
  - add (explicit) default permissions:
    - contents: read
    - pull-requests: write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized default GitHub Actions permissions across workflows to follow least-privilege best practices.
  * Ensures pull request automation retains required access while jobs without explicit permissions inherit safe defaults.
  * No changes to workflow triggers or job logic; build and deploy behavior remains unchanged, with improved security and configuration clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->