### PR TITLE
Fix altSnapshotDeploymentRepository (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TBD
 
 
+## [3.3.2]
+<!-- !!! Align version in badge URLs as well !!! -->
+[![3.3.2 Badge](https://img.shields.io/maven-central/v/io.github.mavenplugins/unleash-maven-plugin?label=Maven%20Central&filter=3.3.2)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.3.2)
+
+### Summary
+- Fix issue when property `altSnapshotDeploymentRepository` is defined - #31, #32
+
+### 🐛 Fixes
+- Fix issue when property `altSnapshotDeploymentRepository` is defined - #31, #32
+
+
 ## [3.3.1]
 <!-- !!! Align version in badge URLs as well !!! -->
 [![3.3.1 Badge](https://img.shields.io/maven-central/v/io.github.mavenplugins/unleash-maven-plugin?label=Maven%20Central&filter=3.3.1)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.3.1)
@@ -437,7 +448,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This is just a dummy placeholder to make the parser of GHCICD/release-notes-from-changelog@v1 happy!
 -->
 
-[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.1..HEAD
+[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.2..HEAD
+[3.3.2]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.1..v3.3.2
 [3.3.1]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.0..v3.3.1
 [3.3.0]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.2.1..v3.3.0
 [3.2.1]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.2.0..v3.2.1

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractUnleashMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractUnleashMojo.java
@@ -254,22 +254,7 @@ public class AbstractUnleashMojo extends AbstractCDIMojo {
   private String altDeploymentRepository;
 
   /**
-   * The alternative repository to use when the project has a snapshot version.
-   *
-   * <b>Note:</b> In version 2.x, the format was <code>id::<i>layout</i>::url</code> where <code><i>layout</i></code>
-   * could be <code>default</code> (ie. Maven 2) or <code>legacy</code> (ie. Maven 1), but since 3.0.0 the layout part
-   * has been removed because Maven 3 only supports Maven 2 repository layout.
-   *
-   * @since 3.3.0
-   * @see AbstractUnleashMojo#altDeploymentRepository
-   */
-  @MojoProduces
-  @Named("altSnapshotDeploymentRepository")
-  @Parameter(property = "altSnapshotDeploymentRepository", required = false)
-  private String altSnapshotDeploymentRepository;
-
-  /**
-   * The alternative repository to use when the project has a final version.
+   * The alternative repository to use when property <code>altReleaseDeploymentRepository</code> is not blank.
    *
    * <b>Note:</b> In version 2.x, the format was <code>id::<i>layout</i>::url</code> where <code><i>layout</i></code>
    * could be <code>default</code> (ie. Maven 2) or <code>legacy</code> (ie. Maven 1), but since 3.0.0 the layout part

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/ReleaseMetadata.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/ReleaseMetadata.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Scm;
@@ -89,9 +88,6 @@ public class ReleaseMetadata {
   @Named("altDeploymentRepository")
   private String altDeploymentRepository;
   @Inject
-  @Named("altSnapshotDeploymentRepository")
-  private String altSnapshotDeploymentRepository;
-  @Inject
   @Named("altReleaseDeploymentRepository")
   private String altReleaseDeploymentRepository;
 
@@ -121,7 +117,7 @@ public class ReleaseMetadata {
    * CDI managed initialization.
    *
    * @throws RuntimeException in case of a {@link MojoExecutionException} thrown inside to meet the CDI
-   *                            {@link PostConstruct} convention.
+   *           {@link PostConstruct} convention.
    */
   @PostConstruct
   public void init() throws RuntimeException {
@@ -317,20 +313,19 @@ public class ReleaseMetadata {
    *
    * @see https://github.com/apache/maven-deploy-plugin/blob/maven-deploy-plugin-3.1.4/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
    * @see https://github.com/shillner/unleash-maven-plugin/pull/101
+   * @see https://github.com/mavenplugins/unleash-maven-plugin/issues/31
    */
   private RemoteRepository getEffectiveDeploymentRepository() throws MojoExecutionException {
     RemoteRepository repo = null;
 
     String altDeploymentRepo;
-    if (ArtifactUtils.isSnapshot(this.project.getVersion()) && this.altSnapshotDeploymentRepository != null) {
-      altDeploymentRepo = this.altSnapshotDeploymentRepository;
-    } else if (!ArtifactUtils.isSnapshot(this.project.getVersion()) && this.altReleaseDeploymentRepository != null) {
+    if (StringUtils.isNotBlank(this.altReleaseDeploymentRepository)) {
       altDeploymentRepo = this.altReleaseDeploymentRepository;
     } else {
       altDeploymentRepo = this.altDeploymentRepository;
     }
 
-    if (altDeploymentRepo != null) {
+    if (StringUtils.isNotBlank(altDeploymentRepo)) {
       this.log.info("Using alternate deployment repository " + altDeploymentRepo);
 
       Matcher matcher = ALT_LEGACY_REPO_SYNTAX_PATTERN.matcher(altDeploymentRepo);


### PR DESCRIPTION
## Changes
- AbstractUnleashMojo.java:
  - remove parameter altSnapshotDeploymentRepository

- ReleaseMetadata.java:
  - remove parameter altSnapshotDeploymentRepository
  - consider altReleaseDeploymentRepository or altDeploymentRepository only

- update CHANGELOG.md

closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to override the release deployment repository (altReleaseDeploymentRepository).
* **Refactor**
  * Removed snapshot-specific override configuration (altSnapshotDeploymentRepository); snapshot-specific overrides are no longer supported.
  * Simplified deployment repository resolution: uses the release override when set, otherwise falls back to the general override.
* **Bug Fixes**
  * Corrected effective deployment repository selection to honor non-blank overrides consistently.
* **Documentation**
  * Added CHANGELOG entry for v3.3.2 and updated comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->