### PR TITLE
Support non standard multimodule structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TBD
 
 
+## [3.3.3]
+<!-- !!! Align version in badge URLs as well !!! -->
+[![3.3.3 Badge](https://img.shields.io/maven-central/v/io.github.mavenplugins/unleash-maven-plugin?label=Maven%20Central&filter=3.3.3)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.3.3)
+
+### Summary
+- Enhance to support Maven non standard multimodule project structure - #33
+
+### 🚀 New Features
+- Enhance to support Maven non standard multimodule project structure - #33
+
+### 📦 Updates
+- pom.xml:
+  - Update property `<version.cdi-plugin-utils>4.0.1</version.cdi-plugin-utils>` -> `<version.cdi-plugin-utils>4.0.2</version.cdi-plugin-utils>`
+
+
 ## [3.3.2]
 <!-- !!! Align version in badge URLs as well !!! -->
 [![3.3.2 Badge](https://img.shields.io/maven-central/v/io.github.mavenplugins/unleash-maven-plugin?label=Maven%20Central&filter=3.3.2)](https://central.sonatype.com/artifact/io.github.mavenplugins/unleash-maven-plugin/3.3.2)
@@ -448,7 +463,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This is just a dummy placeholder to make the parser of GHCICD/release-notes-from-changelog@v1 happy!
 -->
 
-[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.2..HEAD
+[Unreleased]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.3..HEAD
+[3.3.3]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.2..v3.3.3
 [3.3.2]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.1..v3.3.2
 [3.3.1]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.3.0..v3.3.1
 [3.3.0]: https://github.com/mavenplugins/unleash-maven-plugin/compare/v3.2.1..v3.3.0

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractUnleashMojo.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/AbstractUnleashMojo.java
@@ -383,6 +383,14 @@ public class AbstractUnleashMojo extends AbstractCDIMojo {
     return env;
   }
 
+  /**
+   * Collects additional deployment repositories configured for the build and returns them as RemoteRepository instances.
+   *
+   * The method includes repositories declared via the `additionalDeploymentRepositories` plugin configuration and
+   * repositories parsed from system properties whose keys start with "multiDeploy.repo".
+   *
+   * @return a set of RemoteRepository objects representing the additional deployment targets
+   */
   @MojoProduces
   @Named("additionalDeployemntRepositories")
   private Set<RemoteRepository> getAdditionalDeploymentRepositories() {
@@ -405,6 +413,16 @@ public class AbstractUnleashMojo extends AbstractCDIMojo {
 
   private File allReactorsBasedir;
 
+  /**
+   * Determine and return the lowest common base directory that contains all reactor projects, validating
+   * that each reactor corresponds to a unique relative path under that base.
+   *
+   * This method computes the common ancestor directory for the current project and all reactor projects,
+   * caches the result, and ensures there is at most one POM per relative path under the computed base.
+   *
+   * @return the common base directory that contains all reactor projects
+   * @throws MojoFailureException if no common ancestor exists or if multiple reactor POMs are found in the same relative directory
+   */
   @MojoProduces
   @Named("allReactorsBasedir")
   private File getAllReactorsBasedir() throws MojoFailureException {

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
@@ -52,6 +52,14 @@ public class DetectReleaseArtifacts implements CDIMojoProcessingStep {
   @Named("allReactorsBasedir")
   private File allReactorsBasedir;
 
+  /**
+   * Detects release artifacts produced during the release build and registers them in
+   * ReleaseMetadata so they can be installed and deployed later.
+   *
+   * @param context the current execution context for this processing step
+   * @throws MojoExecutionException if an I/O error occurs while reading or preparing artifact files
+   * @throws MojoFailureException if expected artifact-spy output is missing for a module
+   */
   @Override
   public void execute(ExecutionContext context) throws MojoExecutionException, MojoFailureException {
     this.log.info(

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/DetectReleaseArtifacts.java
@@ -41,8 +41,6 @@ public class DetectReleaseArtifacts implements CDIMojoProcessingStep {
   @Inject
   private Logger log;
   @Inject
-  private MavenProject project;
-  @Inject
   @Named("reactorProjects")
   private List<MavenProject> reactorProjects;
   @Inject
@@ -50,6 +48,9 @@ public class DetectReleaseArtifacts implements CDIMojoProcessingStep {
   @Inject
   @Named("unleashOutputFolder")
   private File unleashOutputFolder;
+  @Inject
+  @Named("allReactorsBasedir")
+  private File allReactorsBasedir;
 
   @Override
   public void execute(ExecutionContext context) throws MojoExecutionException, MojoFailureException {
@@ -71,7 +72,7 @@ public class DetectReleaseArtifacts implements CDIMojoProcessingStep {
           // in case of pom artifacts the poms are copied to a different location to ensure we upload the correct
           // version of the pom since the pom evolves during the release build.
           if (Objects.equal(p.getFile().getName(), relativePath)) {
-            relativePath = new FileToRelativePath(this.project.getBasedir()).apply(p.getFile());
+            relativePath = new FileToRelativePath(this.allReactorsBasedir).apply(p.getFile());
             artifactFile = new File(this.unleashOutputFolder, relativePath);
             artifactFile.getParentFile().mkdirs();
 

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/tycho/AbstractTychoVersionsStep.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/tycho/AbstractTychoVersionsStep.java
@@ -151,6 +151,16 @@ public abstract class AbstractTychoVersionsStep implements CDIMojoProcessingStep
     }
   }
 
+  /**
+   * Prepare and configure a Tycho VersionsEngine for the current reactor projects.
+   *
+   * Ensures a ProjectMetadataReader is available (initialized with the reactor base directory)
+   * and uses it to populate and configure the VersionsEngine.
+   *
+   * @return the configured VersionsEngine ready to apply version changes for the reactor projects
+   * @throws MojoExecutionException if Tycho cannot read the project structure or other execution errors occur
+   * @throws MojoFailureException if a required Plexus component cannot be looked up
+   */
   private VersionsEngine initializeVersionsEngine() throws MojoExecutionException, MojoFailureException {
     if (this.metadataReader == null) {
       this.metadataReader = lookup(ProjectMetadataReader.class);

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/tycho/AbstractTychoVersionsStep.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/steps/actions/tycho/AbstractTychoVersionsStep.java
@@ -1,5 +1,6 @@
 package com.itemis.maven.plugins.unleash.steps.actions.tycho;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,9 @@ public abstract class AbstractTychoVersionsStep implements CDIMojoProcessingStep
   @Inject
   @Named("reactorProjects")
   private List<MavenProject> reactorProjects;
+  @Inject
+  @Named("allReactorsBasedir")
+  private File allReactorsBasedir;
   private Map<ArtifactCoordinates, Document> cachedPOMs;
   private Map<ArtifactCoordinates, String> cachedModuleVersions;
   private ProjectMetadataReader metadataReader;
@@ -151,7 +155,7 @@ public abstract class AbstractTychoVersionsStep implements CDIMojoProcessingStep
     if (this.metadataReader == null) {
       this.metadataReader = lookup(ProjectMetadataReader.class);
       try {
-        this.metadataReader.addBasedir(this.project.getBasedir());
+        this.metadataReader.addBasedir(this.allReactorsBasedir);
       } catch (IOException e) {
         throw new MojoExecutionException("Tycho was unable to read the project structure!", e);
       }

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
@@ -47,6 +47,11 @@ public class DevVersionUtil {
   @Named("allReactorsBasedir")
   private File allReactorsBasedir;
 
+  /**
+   * Initialize the SCM provider reference for this instance.
+   *
+   * Called after dependency injection to obtain and store the ScmProvider from the ScmProviderRegistry.
+   */
   @PostConstruct
   private void init() {
     this.scmProvider = this.scmProviderRegistry.getProvider();
@@ -88,6 +93,14 @@ public class DevVersionUtil {
     }
   }
 
+  /**
+   * Commit changed POMs and push the commits to the remote SCM, merging with remote changes if needed.
+   *
+   * Records the remote revision before the commit and the resulting revision after the commit in
+   * release metadata.
+   *
+   * @param commitPomsOnly if true, restrict the commit to the reactor projects' POM files; if false, include all detected changes
+   */
   public void commitChanges(boolean commitPomsOnly) {
     this.log.debug(
         "\tCommitting changed POMs of all modules and pushing to remote repository. Merging with remote changes if necessary.");

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
@@ -33,8 +33,6 @@ public class DevVersionUtil {
   @Inject
   private Logger log;
   @Inject
-  private MavenProject project;
-  @Inject
   @Named("reactorProjects")
   private List<MavenProject> reactorProjects;
   @Inject

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/DevVersionUtil.java
@@ -1,5 +1,6 @@
 package com.itemis.maven.plugins.unleash.util;
 
+import java.io.File;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -44,6 +45,9 @@ public class DevVersionUtil {
   @Inject
   private ScmProviderRegistry scmProviderRegistry;
   private ScmProvider scmProvider;
+  @Inject
+  @Named("allReactorsBasedir")
+  private File allReactorsBasedir;
 
   @PostConstruct
   private void init() {
@@ -98,7 +102,7 @@ public class DevVersionUtil {
 
     Builder requestBuilder = CommitRequest.builder().merge().mergeClient(new ScmPomVersionsMergeClient())
         .message(message.toString()).push();
-    FileToRelativePath pathConverter = new FileToRelativePath(this.project.getBasedir());
+    FileToRelativePath pathConverter = new FileToRelativePath(this.allReactorsBasedir);
     if (commitPomsOnly) {
       for (MavenProject p : this.reactorProjects) {
         requestBuilder.addPaths(pathConverter.apply(p.getFile()));

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/scm/ScmProviderRegistry.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/scm/ScmProviderRegistry.java
@@ -1,5 +1,6 @@
 package com.itemis.maven.plugins.unleash.util.scm;
 
+import java.io.File;
 import java.lang.reflect.Method;
 
 import org.apache.commons.lang3.StringUtils;
@@ -59,6 +60,9 @@ public class ScmProviderRegistry {
   @Inject
   @Named("scmSshPrivateKeyEnvVar")
   private String scmSshPrivateKeyEnvVar;
+  @Inject
+  @Named("allReactorsBasedir")
+  private File allReactorsBasedir;
   private String scmProviderName;
   private ScmProvider provider;
 
@@ -83,8 +87,7 @@ public class ScmProviderRegistry {
         this.provider = this.providers.select(new ScmProviderTypeLiteral(this.scmProviderName)).get();
         checkProviderAPI();
 
-        DefaultScmProviderInitialization initialization = new DefaultScmProviderInitialization(
-            this.project.getBasedir());
+        DefaultScmProviderInitialization initialization = new DefaultScmProviderInitialization(this.allReactorsBasedir);
         initialization.setLogger(new JavaLoggerAdapter(this.provider.getClass().getName(), this.log));
         initialization.setUsername(getScmUsername());
         initialization.setUsername(getScmUsername());

--- a/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/scm/ScmProviderRegistry.java
+++ b/plugin/src/main/java/com/itemis/maven/plugins/unleash/util/scm/ScmProviderRegistry.java
@@ -81,6 +81,12 @@ public class ScmProviderRegistry {
     this.scmProviderName = providerName.orNull();
   }
 
+  /**
+   * Provides the initialized ScmProvider instance for the current Maven project.
+   *
+   * @return the initialized ScmProvider instance
+   * @throws IllegalStateException if no matching provider is available, provider initialization fails, or the provider's API is incompatible
+   */
   public ScmProvider getProvider() throws IllegalStateException {
     if (this.provider == null) {
       try {

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -56,18 +57,16 @@ public class FileToRelativePathTest {
   @Test
   @UseDataProvider("windows_IsParentOf")
   public void testWindowsIsParentOf(String parentPath, String childPath) {
-    if (!SystemUtils.IS_OS_WINDOWS) {
-      return;
-    }
+    // Skip test in a non Windows runtime
+    Assume.assumeTrue("Windows-specific behavior", SystemUtils.IS_OS_WINDOWS);
     Assert.assertTrue(new FileToRelativePath(new File(parentPath)).isParentOfOrSame(new File(childPath)));
   }
 
   @Test
   @UseDataProvider("windows_IsParentOf")
   public void testWindowsIsNotParentOf(String parentPath, String childPath) {
-    if (!SystemUtils.IS_OS_WINDOWS) {
-      return;
-    }
+    // Skip test in a non Windows runtime
+    Assume.assumeTrue("Windows-specific behavior", SystemUtils.IS_OS_WINDOWS);
     File fileParentPath = new File(parentPath);
     File fileChildPath = new File(childPath);
     Assert.assertTrue(!new FileToRelativePath(fileChildPath).isParentOfOrSame(fileParentPath)
@@ -77,18 +76,16 @@ public class FileToRelativePathTest {
   @Test
   @UseDataProvider("unix_IsParentOf")
   public void testUnixIsParentOf(String parentPath, String childPath) {
-    if (SystemUtils.IS_OS_WINDOWS) {
-      return;
-    }
+    // Skip test in a Windows runtime
+    Assume.assumeFalse("Unix-specific behavior", SystemUtils.IS_OS_WINDOWS);
     Assert.assertTrue(new FileToRelativePath(new File(parentPath)).isParentOfOrSame(new File(childPath)));
   }
 
   @Test
   @UseDataProvider("unix_IsParentOf")
   public void testUnixIsNotParentOf(String parentPath, String childPath) {
-    if (SystemUtils.IS_OS_WINDOWS) {
-      return;
-    }
+    // Skip test in a Windows runtime
+    Assume.assumeFalse("Unix-specific behavior", SystemUtils.IS_OS_WINDOWS);
     File fileParentPath = new File(parentPath);
     File fileChildPath = new File(childPath);
     Assert.assertTrue(!new FileToRelativePath(fileChildPath).isParentOfOrSame(fileParentPath)

--- a/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
+++ b/plugin/src/test/java/com/itemis/maven/plugins/unleash/util/functions/FileToRelativePathTest.java
@@ -3,6 +3,7 @@ package com.itemis.maven.plugins.unleash.util.functions;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 import com.itemis.maven.plugins.unleash.scm.utils.FileToRelativePath;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
 @RunWith(DataProviderRunner.class)
 public class FileToRelativePathTest {
@@ -39,4 +41,57 @@ public class FileToRelativePathTest {
     }
   }
 
+  @DataProvider
+  public static Object[][] windows_IsParentOf() {
+    return new Object[][] { { "C:/abc/def", "C:/abc/def/ghi" }, { "C:/abc/def/ghi", "C:/abc/def/ghi" },
+        { "c:/abc/def", "C:/abc/def/ghi" }, { "C:/abc/def", "c:\\abc\\def\\ghi" },
+        { "C:\\abc\\def", "c:\\abc\\def\\ghi" } };
+  };
+
+  @DataProvider
+  public static Object[][] unix_IsParentOf() {
+    return new Object[][] { { "/c/abc/def", "/c/abc/def/ghi" }, { "/c/abc/def/ghi", "/c/abc/def/ghi" } };
+  };
+
+  @Test
+  @UseDataProvider("windows_IsParentOf")
+  public void testWindowsIsParentOf(String parentPath, String childPath) {
+    if (!SystemUtils.IS_OS_WINDOWS) {
+      return;
+    }
+    Assert.assertTrue(new FileToRelativePath(new File(parentPath)).isParentOfOrSame(new File(childPath)));
+  }
+
+  @Test
+  @UseDataProvider("windows_IsParentOf")
+  public void testWindowsIsNotParentOf(String parentPath, String childPath) {
+    if (!SystemUtils.IS_OS_WINDOWS) {
+      return;
+    }
+    File fileParentPath = new File(parentPath);
+    File fileChildPath = new File(childPath);
+    Assert.assertTrue(!new FileToRelativePath(fileChildPath).isParentOfOrSame(fileParentPath)
+        || StringUtils.isEmpty(new FileToRelativePath(fileChildPath).apply(fileParentPath)));
+  }
+
+  @Test
+  @UseDataProvider("unix_IsParentOf")
+  public void testUnixIsParentOf(String parentPath, String childPath) {
+    if (SystemUtils.IS_OS_WINDOWS) {
+      return;
+    }
+    Assert.assertTrue(new FileToRelativePath(new File(parentPath)).isParentOfOrSame(new File(childPath)));
+  }
+
+  @Test
+  @UseDataProvider("unix_IsParentOf")
+  public void testUnixIsNotParentOf(String parentPath, String childPath) {
+    if (SystemUtils.IS_OS_WINDOWS) {
+      return;
+    }
+    File fileParentPath = new File(parentPath);
+    File fileChildPath = new File(childPath);
+    Assert.assertTrue(!new FileToRelativePath(fileChildPath).isParentOfOrSame(fileParentPath)
+        || StringUtils.isEmpty(new FileToRelativePath(fileChildPath).apply(fileParentPath)));
+  }
 }

--- a/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
+++ b/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
@@ -29,6 +29,12 @@ public class FileToRelativePath implements Function<File, String> {
     return workingDirURI.relativize(fileURI).toString();
   }
 
+  /**
+   * Convert a File to a URI, normalizing the Windows drive letter to lowercase when running on Windows.
+   *
+   * @param file the file whose URI to produce; its drive letter will be lowercased on Windows if present
+   * @return the URI for the file, with a lowercased drive letter on Windows when applicable
+   */
   private URI toURIWithNormalizedDriveLetterOnWindows(File file) {
     if (SystemUtils.IS_OS_WINDOWS) {
       // On Windows OS deviations in character case of the drive letter may occur
@@ -45,6 +51,12 @@ public class FileToRelativePath implements Function<File, String> {
     return file.toURI();
   }
 
+  /**
+   * Determines whether the given file is the same as or a descendant of the working directory.
+   *
+   * @param f the file to test
+   * @return {@code true} if the file is the same as or located inside the working directory, {@code false} otherwise
+   */
   public boolean isParentOfOrSame(File f) {
     return !StringUtils.startsWith(apply(f), "file:");
   }

--- a/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
+++ b/scm-provider-api/src/main/java/com/itemis/maven/plugins/unleash/scm/utils/FileToRelativePath.java
@@ -3,6 +3,7 @@ package com.itemis.maven.plugins.unleash.scm.utils;
 import java.io.File;
 import java.net.URI;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import com.google.common.base.Function;
@@ -43,4 +44,9 @@ public class FileToRelativePath implements Function<File, String> {
     }
     return file.toURI();
   }
+
+  public boolean isParentOfOrSame(File f) {
+    return !StringUtils.startsWith(apply(f), "file:");
+  }
+
 }


### PR DESCRIPTION
## Issue
Maven projects that do not follow the Maven standard project structure are making the unleash plugin to fail.
A non standard Maven project may start with a project parent POM in a subdirectory rather than in the projects root folder.
Currently such projects make the unleash:perform goal failing late in the perform workflow.
There is no specific error message in that case which makes a root cause analysis hard and time consuming.

## Solution
Determine the common base directory for all multimodule reactors in the beginning of the unleash:perform execution.
Use this all reactors base directory instead of `this.project.getBasedir()`.
Abort with an appropriate detailed error message in case of a project structure that is not supported.

## Changes
- AbstractUnleashMojo.java:
  - add method to produce "allReactorsBasedir"

- DetectReleaseArtifacts.java, AbstractTychoVersionsStep.java, DevVersionUtil.java, ScmProviderRegistry.java:
  - replace usage of this.project.getBasedir() by injected "allReactorsBasedir"

- FileToRelativePath.java:
  - add method public boolean isParentOfOrSame(File f)

- FileToRelativePathTest.java:
  - enhance for testing FileToRelativePath.isParentOfOrSame(File f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects a common base directory for multi-module builds and gathers additional deployment repositories from configuration/system properties.

* **Bug Fixes**
  * More robust cross-module relative-path handling for artifact detection, SCM and metadata operations.
  * Clearer logging and error reporting for invalid reactor structures.

* **Tests**
  * Added OS-aware tests for parent/child path relationships (Windows and Unix).

* **Documentation**
  * Added 3.3.3 entry in CHANGELOG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->